### PR TITLE
Fix typo in print_verbose_error(), see #9219.

### DIFF
--- a/lib/patch_finder/core/helper.rb
+++ b/lib/patch_finder/core/helper.rb
@@ -15,7 +15,7 @@ module PatchFinder
     end
 
     def print_verbose_error(msg='')
-      print_error(msge) if self.verbose
+      print_error(msg) if self.verbose
     end
 
     # Prints a status message.


### PR DESCRIPTION
Title says it all.  See MSF issue [#9219](https://github.com/rapid7/metasploit-framework/issues/9219).