### PR TITLE
Move away from deprecated URI.escape (ruby 3.1 compat)

### DIFF
--- a/lib/patch_finder/core/thread_pool.rb
+++ b/lib/patch_finder/core/thread_pool.rb
@@ -5,7 +5,7 @@ module PatchFinder
 
     # Initializes the pool.
     #
-    # @param size [Fixnum] Max number of threads to be running at the same time.
+    # @param size [Integer] Max number of threads to be running at the same time.
     # @return [void]
     def initialize(size)
       @size = size

--- a/lib/patch_finder/engine/msu/google.rb
+++ b/lib/patch_finder/engine/msu/google.rb
@@ -80,7 +80,7 @@ module PatchFinder
         def search(opts = {})
           starting_index = opts[:starting_index]
 
-          search_string = URI.escape([
+          search_string = CGI.escape([
             opts[:keyword],
             'intitle:"Microsoft Security Bulletin"',
             '-"Microsoft Security Bulletin Summary"'

--- a/lib/patch_finder/engine/msu/google.rb
+++ b/lib/patch_finder/engine/msu/google.rb
@@ -74,7 +74,7 @@ module PatchFinder
         # Searches the Google API.
         #
         # @param opts [Hash]
-        # @option opts [Fixnum] :starting_index
+        # @option opts [Integer] :starting_index
         # @option opts [String] :keyword
         # @return [Hash] JSON
         def search(opts = {})
@@ -122,7 +122,7 @@ module PatchFinder
         # Returns totalResults
         #
         # @param j [Hash] JSON response.
-        # @return [Fixnum]
+        # @return [Integer]
         def get_total_results(j)
           j['queries']['request'].first['totalResults'].to_i
         end
@@ -130,7 +130,7 @@ module PatchFinder
         # Returns startIndex
         #
         # @param j [Hash] JSON response.
-        # @return [Fixnum]
+        # @return [Integer]
         def get_next_index(j)
           j['queries']['nextPage'] ? j['queries']['nextPage'].first['startIndex'] : 0
         end

--- a/spec/lib/engine/msu/google_spec.rb
+++ b/spec/lib/engine/msu/google_spec.rb
@@ -134,16 +134,16 @@ RSpec.describe PatchFinder::Engine::MSU::Google do
   end
 
   describe '#get_total_results' do
-    it 'returns a fixnum' do
+    it 'returns a Integer' do
       total = subject.get_total_results(JSON.parse(json_data.body))
-      expect(total).to be_kind_of(Fixnum)
+      expect(total).to be_kind_of(Integer)
     end
   end
 
   describe '#get_next_index' do
-    it 'returns a fixnum' do
+    it 'returns a Integer' do
       i = subject.get_next_index(JSON.parse(json_data.body))
-      expect(i).to be_kind_of(Fixnum)
+      expect(i).to be_kind_of(Integer)
     end
   end
 end


### PR DESCRIPTION
See https://stackoverflow.com/questions/68174351/undefined-method-escape-for-urimodule
and ruby/uri@61c6a47.

CGI.escape seems to work here.